### PR TITLE
접근성 개선 작업 적용

### DIFF
--- a/src/components/atoms/AuthorBadge/AuthorBadge.tsx
+++ b/src/components/atoms/AuthorBadge/AuthorBadge.tsx
@@ -16,7 +16,7 @@ const AuthorBadge = ({ author, onClick }: Props) => {
   return (
     <Link href={`/author/${id}`} onClick={onClick}>
       <AuthorBadgeWrapper>
-        <CompanyImage src={logoUrl} alt="authorLogo" width={24} height={24} />
+        <CompanyImage src={logoUrl} alt="" width={24} height={24} />
         <Text size={14} weight="medium">
           {name}
         </Text>

--- a/src/components/atoms/AuthorBadge/AuthorBadge.tsx
+++ b/src/components/atoms/AuthorBadge/AuthorBadge.tsx
@@ -1,20 +1,21 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { type HTMLAttributes } from 'react';
 
 import { Text, styled } from '@nextui-org/react';
 
 import { type Author } from '@/types/data';
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLAnchorElement> {
   author: Author;
   onClick?: () => void;
 }
 
-const AuthorBadge = ({ author, onClick }: Props) => {
+const AuthorBadge = ({ author, onClick, ...props }: Props) => {
   const { id, name, logoUrl } = author;
 
   return (
-    <Link href={`/author/${id}`} onClick={onClick}>
+    <Link href={`/author/${id}`} onClick={onClick} {...props}>
       <AuthorBadgeWrapper>
         <CompanyImage src={logoUrl} alt="" width={24} height={24} />
         <Text size={14} weight="medium">

--- a/src/components/atoms/Logo/Logo.tsx
+++ b/src/components/atoms/Logo/Logo.tsx
@@ -9,7 +9,7 @@ interface Props {
 const Logo = (props: Props) => {
   return (
     <LogoWrapper {...props}>
-      <Image src="/logo.svg" alt="k-tech-feed" width={32} height={32} />
+      <Image src="/logo.svg" alt="" width={32} height={32} />
       <LogoText hideIn="sm">K_TECH_FEED</LogoText>
     </LogoWrapper>
   );

--- a/src/components/atoms/SearchInput/SearchInput.tsx
+++ b/src/components/atoms/SearchInput/SearchInput.tsx
@@ -10,13 +10,18 @@ interface Props {
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  ariaLabel?: string;
 }
 
 const SearchInput = forwardRef<HTMLInputElement, Props>(
-  ({ onChange, onFocus = () => {}, onBlur = () => {}, onKeyDown = () => {}, ...rest }, ref) => {
+  (
+    { onChange, onFocus = () => {}, onBlur = () => {}, onKeyDown = () => {}, ariaLabel, ...rest },
+    ref
+  ) => {
     return (
       <Input
         {...rest}
+        aria-label={ariaLabel}
         ref={ref}
         clearable
         size="lg"

--- a/src/components/atoms/SearchInput/SearchInput.tsx
+++ b/src/components/atoms/SearchInput/SearchInput.tsx
@@ -5,6 +5,7 @@ import { IconSearch } from '@tabler/icons-react';
 
 interface Props {
   css?: CSS;
+
   placeholder: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
@@ -21,6 +22,7 @@ const SearchInput = forwardRef<HTMLInputElement, Props>(
     return (
       <Input
         {...rest}
+        id="search-input"
         aria-label={ariaLabel}
         ref={ref}
         clearable

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,3 +24,4 @@ export { default as ArticleSection } from './templates/ArticleSection/ArticleSec
 export { default as ArticleLoading } from './templates/ArticleLoading/ArticleLoading';
 export { default as ArticleContentSection } from './templates/ArticleContentSection/ArticleContentSection';
 export { default as TrendSection } from './templates/TrendSection/TrendSection';
+export { default as PopoverArea } from './templates/PopoverArea/PopoverArea';

--- a/src/components/molecules/AuthorTimeBadge/AuthorTimeBadge.tsx
+++ b/src/components/molecules/AuthorTimeBadge/AuthorTimeBadge.tsx
@@ -9,11 +9,12 @@ interface Props extends Pick<Article, 'timestamp'> {
 }
 
 const AuthorTimeBadge = ({ author, timestamp }: Props) => {
+  const agoDateTime = dateTimeFormat(timestamp);
   return (
     <AuthorTimestampWrapper>
       <AuthorBadge author={author} />
-      <Text size={14} color="$gray800">
-        &nbsp;· {dateTimeFormat(timestamp)}
+      <Text size={14} color="$gray800" tabIndex={0} aria-label={`${agoDateTime}에 작성됨`}>
+        &nbsp;· {agoDateTime}
       </Text>
     </AuthorTimestampWrapper>
   );

--- a/src/components/molecules/HashTagBadge/HashTagBadge.tsx
+++ b/src/components/molecules/HashTagBadge/HashTagBadge.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 const HashTagBadge = ({ hashtag, onClick }: Props) => {
   return (
-    <Link href={`/hashtag/${hashtag}`} onClick={onClick}>
+    <Link href={`/hashtag/${hashtag}`} onClick={onClick} aria-label={hashtag}>
       <Badge color={CategoryColor(hashtag)}># {hashtag}</Badge>
     </Link>
   );

--- a/src/components/molecules/HashTagBadge/HashTagBadge.tsx
+++ b/src/components/molecules/HashTagBadge/HashTagBadge.tsx
@@ -1,16 +1,17 @@
 import Link from 'next/link';
+import { type HTMLAttributes } from 'react';
 
 import { Badge } from '@/components';
 import { CategoryColor } from '@/utils/categoryColors';
 
-interface Props {
+interface Props extends HTMLAttributes<HTMLAnchorElement> {
   hashtag: string;
   onClick?: () => void;
 }
 
-const HashTagBadge = ({ hashtag, onClick }: Props) => {
+const HashTagBadge = ({ hashtag, onClick, ...props }: Props) => {
   return (
-    <Link href={`/hashtag/${hashtag}`} onClick={onClick} aria-label={hashtag}>
+    <Link href={`/hashtag/${hashtag}`} onClick={onClick} {...props}>
       <Badge color={CategoryColor(hashtag)}># {hashtag}</Badge>
     </Link>
   );

--- a/src/components/organisms/ArticleCard/ArticleCard.styles.tsx
+++ b/src/components/organisms/ArticleCard/ArticleCard.styles.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@nextui-org/react';
 
-const ArticleCardWrapper = styled('div', {
+const ArticleCardWrapper = styled('li', {
   display: 'flex',
   flexDirection: 'column',
   gap: '12px',

--- a/src/components/organisms/ArticleCard/ArticleCard.tsx
+++ b/src/components/organisms/ArticleCard/ArticleCard.tsx
@@ -1,5 +1,3 @@
-import { forwardRef } from 'react';
-
 import { Text } from '@nextui-org/react';
 
 import { AuthorTimeBadge, HashTagBadge } from '@/components';
@@ -18,11 +16,11 @@ interface Props {
   article: Article;
 }
 
-const ArticleCard = forwardRef<HTMLDivElement, Props>(({ article }: Props, ref) => {
+const ArticleCard = ({ article }: Props) => {
   const { id, title, author, timestamp, summary, hashtags, thumbnailUrl } = article;
 
   return (
-    <ArticleCardWrapper ref={ref}>
+    <ArticleCardWrapper aria-label={title}>
       <AuthorTimeBadge author={author} timestamp={timestamp} />
       <ArticleContent
         href={`${process.env.NEXT_PUBLIC_API_URL as string}/articles/${id}`}
@@ -45,6 +43,7 @@ const ArticleCard = forwardRef<HTMLDivElement, Props>(({ article }: Props, ref) 
               '-webkit-line-clamp': 3,
               '-webkit-box-orient': 'vertical',
             }}
+            aria-hidden={true}
           >
             {summary}
           </Text>
@@ -52,7 +51,7 @@ const ArticleCard = forwardRef<HTMLDivElement, Props>(({ article }: Props, ref) 
         <ArticleThumbnail>
           <ArticleThumbnailImage
             src={thumbnailUrl}
-            alt="thumbnail"
+            alt=""
             fill
             sizes="180px"
             style={{
@@ -68,7 +67,7 @@ const ArticleCard = forwardRef<HTMLDivElement, Props>(({ article }: Props, ref) 
       </BadgeWrapper>
     </ArticleCardWrapper>
   );
-});
+};
 
 ArticleCard.displayName = 'ArticleCard';
 

--- a/src/components/organisms/ArticleCard/ArticleCard.tsx
+++ b/src/components/organisms/ArticleCard/ArticleCard.tsx
@@ -62,7 +62,7 @@ const ArticleCard = ({ article }: Props) => {
       </ArticleContent>
       <BadgeWrapper>
         {hashtags.map((hashtag, idx) => (
-          <HashTagBadge hashtag={hashtag} key={idx} />
+          <HashTagBadge hashtag={hashtag} key={idx} aria-label={`해시태그 ${hashtag}`} />
         ))}
       </BadgeWrapper>
     </ArticleCardWrapper>

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -17,11 +17,11 @@ const Header = () => {
       as="header"
     >
       <Navbar.Brand css={{ cursor: 'pointer' }}>
-        <Link href="/">
+        <Link href="/" aria-label="home으로 이동">
           <Logo />
         </Link>
       </Navbar.Brand>
-      <Navbar.Content css={{ alignSelf: 'center' }}>
+      <Navbar.Content css={{ alignSelf: 'center' }} as="div" role="searchbox">
         <HeaderSerachInput />
       </Navbar.Content>
       <Navbar.Brand css={{ cursor: 'pointer', visibility: 'hidden' }}>

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -8,7 +8,14 @@ import HeaderSerachInput from './HeaderSearchInput';
 
 const Header = () => {
   return (
-    <Navbar variant="sticky" css={{ zIndex: 1000 }} disableShadow maxWidth="fluid" isBordered>
+    <Navbar
+      variant="sticky"
+      css={{ zIndex: 1000 }}
+      disableShadow
+      maxWidth="fluid"
+      isBordered
+      as="header"
+    >
       <Navbar.Brand css={{ cursor: 'pointer' }}>
         <Link href="/">
           <Logo />

--- a/src/components/organisms/Header/HeaderSearchInput.tsx
+++ b/src/components/organisms/Header/HeaderSearchInput.tsx
@@ -20,8 +20,8 @@ const HeaderSerachInput = () => {
   return (
     <SearchInput
       ref={ref}
-      aria-label="search"
-      placeholder="검색"
+      ariaLabel="검색어 입력창"
+      placeholder="검색어를 입력해주세요."
       onChange={(e) => {
         setInput(e.target.value);
       }}

--- a/src/components/organisms/SearchPopover/SearchPopover.tsx
+++ b/src/components/organisms/SearchPopover/SearchPopover.tsx
@@ -1,4 +1,4 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRecoilValue_TRANSITION_SUPPORT_UNSTABLE } from 'recoil';
 
 import { Loading, styled } from '@nextui-org/react';
@@ -21,9 +21,22 @@ const SearchPopover = () => {
     },
   });
 
+  useEffect(() => {
+    const handleKeyDownEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closePopover();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDownEsc);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDownEsc);
+    };
+  }, [closePopover]);
+
   return (
     <PopoverBackground>
-      <PopoverWrapper ref={ref}>
+      <PopoverWrapper ref={ref} role="dialog">
         <Suspense
           fallback={
             <Loading

--- a/src/components/organisms/SearchPopover/SearchPopoverContent.tsx
+++ b/src/components/organisms/SearchPopover/SearchPopoverContent.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { type KeyboardEvent, useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
 
 import { Text, styled } from '@nextui-org/react';
@@ -11,76 +12,126 @@ import { searchInputAtom } from '@/recoils/atoms/searchInputAtom';
 
 interface Props {
   keyword: string;
+  firstA11yElement?: React.MutableRefObject<HTMLElement | null>;
+  lastA11yElement?: React.MutableRefObject<HTMLElement | null>;
 }
 
 const SearchPopoverContent = ({ keyword }: Props) => {
   const { keywords, authors, hashtags } = useRelatedQueries(keyword);
-  const { isPopoverOpen, closePopover } = usePopover();
+  const { closePopover } = usePopover();
   const setInputValue = useSetRecoilState(searchInputAtom);
+  const firstElement = useRef<HTMLElement>(null);
 
   const handleClickSearchResult = (resultKeyword: string) => () => {
     setInputValue(resultKeyword);
     closePopover();
   };
 
+  const handleKeyDownFirstElement = (e: KeyboardEvent) => {
+    if (e.shiftKey && e.key === 'Tab') {
+      e.preventDefault();
+      document.getElementById('search-input')?.focus();
+      closePopover();
+    }
+  };
+
+  const handleKeyDownLastElement = (e: KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      document.getElementById('search-input')?.focus();
+      closePopover();
+    }
+    if (e.key === 'Tab') {
+      if (e.shiftKey) return;
+      e.preventDefault();
+      firstElement.current?.focus();
+    }
+  };
+
   return (
-    <ContentWrapper role="dialog" aria-modal={isPopoverOpen}>
-      <ContentSection>
-        <Text size={20} weight="bold">
-          검색어
-        </Text>
-        <ContentSectionRows>
-          {keywords?.length === 0 && <Text weight="semibold">관련 검색어가 없습니다.</Text>}
-          {keywords?.map((keyword, idx) => (
-            <Link
-              key={idx}
-              aria-label={`검색어 ${keyword}`}
-              href={`/keyword/${keyword}`}
-              onClick={handleClickSearchResult(keyword)}
-            >
-              <Keyword>
-                <IconSearch color="gray" />
-                <Text size={16} weight="normal">
-                  {keyword}
-                </Text>
-              </Keyword>
-            </Link>
-          ))}
-        </ContentSectionRows>
-      </ContentSection>
-      <ContentSection>
-        <Text size={20} weight="bold">
-          작성자
-        </Text>
-        <ContentSectionRows>
-          {authors?.length === 0 && <Text weight="semibold">관련 작성자가 없습니다.</Text>}
-          {authors?.map((author, idx) => (
-            <AuthorBadge
-              key={idx}
-              aria-label={`작성자 ${keyword}`}
-              author={author}
-              onClick={handleClickSearchResult(author.name)}
-            />
-          ))}
-        </ContentSectionRows>
-      </ContentSection>
-      <ContentSection>
-        <Text size={20} weight="bold">
-          해시태그
-        </Text>
-        <ContentSectionRows>
-          {hashtags?.length === 0 && <Text weight="semibold">관련 해시태그가 없습니다.</Text>}
-          {hashtags?.map((hashtag, idx) => (
-            <HashTagBadge
-              key={idx}
-              aria-label={`해시태그 ${hashtag}`}
-              hashtag={hashtag}
-              onClick={handleClickSearchResult(hashtag)}
-            />
-          ))}
-        </ContentSectionRows>
-      </ContentSection>
-    </ContentWrapper>
+    <>
+      <ContentWrapper>
+        <ContentSection>
+          <Text
+            size={20}
+            weight="semibold"
+            as="h3"
+            tabIndex={0}
+            ref={firstElement}
+            onKeyDown={handleKeyDownFirstElement}
+          >
+            검색어
+          </Text>
+          <ContentSectionRows>
+            {keywords?.length === 0 && (
+              <Text weight="semibold" tabIndex={0}>
+                관련 검색어가 없습니다.
+              </Text>
+            )}
+            {keywords?.map((keyword, idx) => (
+              <Link
+                key={idx}
+                aria-label={`검색어 ${keyword}`}
+                href={`/keyword/${keyword}`}
+                onClick={handleClickSearchResult(keyword)}
+              >
+                <Keyword>
+                  <IconSearch color="gray" />
+                  <Text size={16} weight="normal">
+                    {keyword}
+                  </Text>
+                </Keyword>
+              </Link>
+            ))}
+          </ContentSectionRows>
+        </ContentSection>
+        <ContentSection>
+          <Text size={20} weight="semibold" tabIndex={0} as="h3">
+            작성자
+          </Text>
+          <ContentSectionRows>
+            {authors?.length === 0 && (
+              <Text weight="semibold" tabIndex={0}>
+                관련 작성자가 없습니다.
+              </Text>
+            )}
+            {authors?.map((author, idx) => (
+              <AuthorBadge
+                key={idx}
+                aria-label={`작성자 ${author.name}`}
+                author={author}
+                onClick={handleClickSearchResult(author.name)}
+              />
+            ))}
+          </ContentSectionRows>
+        </ContentSection>
+        <ContentSection>
+          <Text size={20} weight="semibold" tabIndex={0} as="h3">
+            해시태그
+          </Text>
+          <ContentSectionRows>
+            {hashtags?.length === 0 && (
+              <Text weight="semibold" tabIndex={0}>
+                관련 해시태그가 없습니다.
+              </Text>
+            )}
+            {hashtags?.map((hashtag, idx) => (
+              <HashTagBadge
+                key={idx}
+                aria-label={`해시태그 ${hashtag}`}
+                hashtag={hashtag}
+                onClick={handleClickSearchResult(hashtag)}
+              />
+            ))}
+          </ContentSectionRows>
+        </ContentSection>
+      </ContentWrapper>
+      <LastFocusedElement
+        tabIndex={0}
+        aria-label="Enter 키를 입력하면 대화상자를 종료합니다."
+        onKeyDown={handleKeyDownLastElement}
+      />
+    </>
   );
 };
 
@@ -108,4 +159,10 @@ const Keyword = styled('div', {
   display: 'flex',
   gap: '8px',
   alignItems: 'center',
+});
+
+const LastFocusedElement = styled('button', {
+  padding: 0,
+  margin: 0,
+  border: 'none',
 });

--- a/src/components/organisms/SearchPopover/SearchPopoverContent.tsx
+++ b/src/components/organisms/SearchPopover/SearchPopoverContent.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 const SearchPopoverContent = ({ keyword }: Props) => {
   const { keywords, authors, hashtags } = useRelatedQueries(keyword);
-  const { closePopover } = usePopover();
+  const { isPopoverOpen, closePopover } = usePopover();
   const setInputValue = useSetRecoilState(searchInputAtom);
 
   const handleClickSearchResult = (resultKeyword: string) => () => {
@@ -24,7 +24,7 @@ const SearchPopoverContent = ({ keyword }: Props) => {
   };
 
   return (
-    <ContentWrapper>
+    <ContentWrapper role="dialog" aria-modal={isPopoverOpen}>
       <ContentSection>
         <Text size={20} weight="bold">
           검색어
@@ -32,7 +32,12 @@ const SearchPopoverContent = ({ keyword }: Props) => {
         <ContentSectionRows>
           {keywords?.length === 0 && <Text weight="semibold">관련 검색어가 없습니다.</Text>}
           {keywords?.map((keyword, idx) => (
-            <Link key={idx} href={`/keyword/${keyword}`} onClick={handleClickSearchResult(keyword)}>
+            <Link
+              key={idx}
+              aria-label={`검색어 ${keyword}`}
+              href={`/keyword/${keyword}`}
+              onClick={handleClickSearchResult(keyword)}
+            >
               <Keyword>
                 <IconSearch color="gray" />
                 <Text size={16} weight="normal">
@@ -50,7 +55,12 @@ const SearchPopoverContent = ({ keyword }: Props) => {
         <ContentSectionRows>
           {authors?.length === 0 && <Text weight="semibold">관련 작성자가 없습니다.</Text>}
           {authors?.map((author, idx) => (
-            <AuthorBadge key={idx} author={author} onClick={handleClickSearchResult(author.name)} />
+            <AuthorBadge
+              key={idx}
+              aria-label={`작성자 ${keyword}`}
+              author={author}
+              onClick={handleClickSearchResult(author.name)}
+            />
           ))}
         </ContentSectionRows>
       </ContentSection>
@@ -61,7 +71,12 @@ const SearchPopoverContent = ({ keyword }: Props) => {
         <ContentSectionRows>
           {hashtags?.length === 0 && <Text weight="semibold">관련 해시태그가 없습니다.</Text>}
           {hashtags?.map((hashtag, idx) => (
-            <HashTagBadge key={idx} hashtag={hashtag} onClick={handleClickSearchResult(hashtag)} />
+            <HashTagBadge
+              key={idx}
+              aria-label={`해시태그 ${hashtag}`}
+              hashtag={hashtag}
+              onClick={handleClickSearchResult(hashtag)}
+            />
           ))}
         </ContentSectionRows>
       </ContentSection>

--- a/src/components/organisms/TrendArticles/TrendArticles.tsx
+++ b/src/components/organisms/TrendArticles/TrendArticles.tsx
@@ -11,7 +11,7 @@ interface Props {
 const TrendArticles = ({ isMobile }: Props) => {
   return (
     <TrendArticlesWrapper>
-      <Text size={20} weight="bold">
+      <Text size={20} weight="semibold" as="h3" css={{ marginBottom: 0 }}>
         인기 아티클
       </Text>
       <Suspense

--- a/src/components/organisms/TrendArticles/TrendArticles.tsx
+++ b/src/components/organisms/TrendArticles/TrendArticles.tsx
@@ -11,7 +11,7 @@ interface Props {
 const TrendArticles = ({ isMobile }: Props) => {
   return (
     <TrendArticlesWrapper>
-      <Text size={20} weight="semibold" as="h3" css={{ marginBottom: 0 }}>
+      <Text size={20} weight="semibold" as="h3" css={{ marginBottom: 0 }} tabIndex={0}>
         인기 아티클
       </Text>
       <Suspense

--- a/src/components/organisms/TrendArticles/TrendArticlesContent.tsx
+++ b/src/components/organisms/TrendArticles/TrendArticlesContent.tsx
@@ -13,7 +13,7 @@ const TrendArticlesContent = ({ isMobile }: Props) => {
   const trendType = useRecoilValue_TRANSITION_SUPPORT_UNSTABLE(trendAtom);
   const { data: trends } = useTrendingArticlesQuery({ type: trendType });
   return (
-    <div>
+    <ul style={{ margin: 0 }}>
       {trends?.slice(0, isMobile ? 1 : 3).map(({ id, title, author, timestamp }, idx) => (
         <TrendArticleItem
           key={idx}
@@ -23,7 +23,7 @@ const TrendArticlesContent = ({ isMobile }: Props) => {
           timestamp={timestamp}
         />
       ))}
-    </div>
+    </ul>
   );
 };
 

--- a/src/components/organisms/TrendArticles/item/TrendArticleItem.tsx
+++ b/src/components/organisms/TrendArticles/item/TrendArticleItem.tsx
@@ -25,7 +25,7 @@ const TrendArticleItem = ({ title, author, timestamp, href }: Props) => {
 
 export default TrendArticleItem;
 
-const ItemWrapper = styled('div', {
+const ItemWrapper = styled('li', {
   display: 'flex',
   flexDirection: 'column',
   padding: '16px 0',

--- a/src/components/organisms/TrendHashTags/TrendHashTags.tsx
+++ b/src/components/organisms/TrendHashTags/TrendHashTags.tsx
@@ -7,7 +7,7 @@ import TrendHashTagsContent from './TrendHashTagsContent';
 const TrendHashTags = () => {
   return (
     <TrendHashTagsWrapper>
-      <Text size={20} weight="semibold" as="h3" css={{ marginBottom: 0 }}>
+      <Text size={20} weight="semibold" as="h3" css={{ marginBottom: 0 }} tabIndex={0}>
         인기 해시태그
       </Text>
       <Suspense

--- a/src/components/organisms/TrendHashTags/TrendHashTags.tsx
+++ b/src/components/organisms/TrendHashTags/TrendHashTags.tsx
@@ -7,7 +7,7 @@ import TrendHashTagsContent from './TrendHashTagsContent';
 const TrendHashTags = () => {
   return (
     <TrendHashTagsWrapper>
-      <Text size={20} weight="bold">
+      <Text size={20} weight="semibold" as="h3" css={{ marginBottom: 0 }}>
         인기 해시태그
       </Text>
       <Suspense

--- a/src/components/organisms/TrendHashTags/TrendHashTagsContent.tsx
+++ b/src/components/organisms/TrendHashTags/TrendHashTagsContent.tsx
@@ -11,7 +11,7 @@ const TrendHashTagsContent = () => {
   const { data: hashTags } = useTrendingHashtagsQuery({ type: trendType });
 
   return (
-    <ContentWrapper>
+    <ContentWrapper role="none">
       {hashTags?.slice(0, 6).map((hashTag, idx) => (
         <HashTagBadge hashtag={hashTag} key={idx} />
       ))}

--- a/src/components/organisms/TrendHashTags/TrendHashTagsContent.tsx
+++ b/src/components/organisms/TrendHashTags/TrendHashTagsContent.tsx
@@ -13,7 +13,7 @@ const TrendHashTagsContent = () => {
   return (
     <ContentWrapper role="none">
       {hashTags?.slice(0, 6).map((hashTag, idx) => (
-        <HashTagBadge hashtag={hashTag} key={idx} />
+        <HashTagBadge hashtag={hashTag} key={idx} aria-label={`해시태그 ${hashTag}`} />
       ))}
     </ContentWrapper>
   );

--- a/src/components/organisms/TrendSelect/TrendSelect.tsx
+++ b/src/components/organisms/TrendSelect/TrendSelect.tsx
@@ -18,15 +18,17 @@ const TrendSelect = () => {
 
   return (
     <TrendSelectWrapper>
-      <Text size={24} weight="bold" css={{ whiteSpace: 'nowrap' }}>
+      <Text size={24} weight="semibold" css={{ whiteSpace: 'nowrap', marginBottom: 0 }} as="h2">
         트렌드
       </Text>
-      <SegmentedControl>
+      <SegmentedControl role="tablist">
         {['weekly', 'monthly'].map((word, idx) => (
           <SegmentedControl.Item
             key={idx}
             isSelected={selectedTrend === word}
             onClick={handleClickTrend(word as Trend)}
+            role="tab"
+            aria-selected={selectedTrend === word ? 'true' : 'false'}
           >
             <Text weight="semibold">{word.slice(0, 1).toUpperCase() + word.slice(1)}</Text>
           </SegmentedControl.Item>

--- a/src/components/organisms/TrendSelect/TrendSelect.tsx
+++ b/src/components/organisms/TrendSelect/TrendSelect.tsx
@@ -18,7 +18,13 @@ const TrendSelect = () => {
 
   return (
     <TrendSelectWrapper>
-      <Text size={24} weight="semibold" css={{ whiteSpace: 'nowrap', marginBottom: 0 }} as="h2">
+      <Text
+        size={24}
+        weight="semibold"
+        css={{ whiteSpace: 'nowrap', marginBottom: 0 }}
+        as="h2"
+        tabIndex={0}
+      >
         트렌드
       </Text>
       <SegmentedControl role="tablist">
@@ -28,7 +34,8 @@ const TrendSelect = () => {
             isSelected={selectedTrend === word}
             onClick={handleClickTrend(word as Trend)}
             role="tab"
-            aria-selected={selectedTrend === word ? 'true' : 'false'}
+            aria-selected={selectedTrend === word}
+            tabIndex={0}
           >
             <Text weight="semibold">{word.slice(0, 1).toUpperCase() + word.slice(1)}</Text>
           </SegmentedControl.Item>

--- a/src/components/templates/ArticleContentSection/ArticleContentSection.tsx
+++ b/src/components/templates/ArticleContentSection/ArticleContentSection.tsx
@@ -38,21 +38,17 @@ const ArticleContentSection = () => {
   );
 
   return (
-    <div>
-      <div style={{ marginTop: '30px' }}>
-        {!articles ||
-          (articles.length === 0 && (
-            <Text size={24} weight="bold">
-              검색 결과가 존재하지 않습니다.
-            </Text>
-          ))}
-      </div>
+    <ul style={{ margin: '0' }}>
+      {(!articles || articles.length === 0) && (
+        <Text size={24} weight="bold">
+          검색 결과가 존재하지 않습니다.
+        </Text>
+      )}
       {articles?.map((article) => (
         <ArticleCard key={article.id} article={article} />
       ))}
-
       <div ref={ref}></div>
-    </div>
+    </ul>
   );
 };
 

--- a/src/components/templates/ArticleSection/ArticleSection.tsx
+++ b/src/components/templates/ArticleSection/ArticleSection.tsx
@@ -18,7 +18,7 @@ const ArticeSection = () => {
 
   return (
     <ArticleSectionWrapper>
-      <Text as="h1" size={32} weight="semibold">
+      <Text as="h1" size={32} weight="semibold" tabIndex={0}>
         {pathname === '/' && '최신 아티클'}
         {pathname.includes('/keyword') && `${(id as string) ?? '아티클'} 에 대한 검색 결과 `}
         {pathname.includes('/author') && `${author?.name ?? '아티클'} 에 대한 검색 결과 `}
@@ -33,7 +33,7 @@ const ArticeSection = () => {
 
 export default ArticeSection;
 
-const ArticleSectionWrapper = styled('div', {
+const ArticleSectionWrapper = styled('article', {
   position: 'relative',
   width: '100%',
 });

--- a/src/components/templates/ArticleSection/ArticleSection.tsx
+++ b/src/components/templates/ArticleSection/ArticleSection.tsx
@@ -18,7 +18,7 @@ const ArticeSection = () => {
 
   return (
     <ArticleSectionWrapper>
-      <Text size={32} weight="bold">
+      <Text as="h1" size={32} weight="semibold">
         {pathname === '/' && '최신 아티클'}
         {pathname.includes('/keyword') && `${(id as string) ?? '아티클'} 에 대한 검색 결과 `}
         {pathname.includes('/author') && `${author?.name ?? '아티클'} 에 대한 검색 결과 `}

--- a/src/components/templates/ContentLayout/ContentLayout.tsx
+++ b/src/components/templates/ContentLayout/ContentLayout.tsx
@@ -12,8 +12,6 @@ export default ContentLayout;
 
 const ContentWrapper = styled('main', {
   height: '100%',
-  display: 'flex',
-  justifyContent: 'center',
   margin: '40px 32px',
   '@sm': {
     margin: '40px auto',

--- a/src/components/templates/ContentLayout/ContentLayout.tsx
+++ b/src/components/templates/ContentLayout/ContentLayout.tsx
@@ -13,7 +13,7 @@ export default ContentLayout;
 const ContentWrapper = styled('main', {
   height: '100%',
   margin: '40px 32px',
-  '@sm': {
+  '@md': {
     margin: '40px auto',
   },
 });

--- a/src/components/templates/PageLayout/PageLayout.tsx
+++ b/src/components/templates/PageLayout/PageLayout.tsx
@@ -2,20 +2,17 @@ import { type PropsWithChildren } from 'react';
 
 import { styled } from '@nextui-org/react';
 
-import { ContentLayout, Header, SearchPopover } from '@/components';
-import usePopover from '@/hooks/utils/usePopover';
+import { ContentLayout, Header, PopoverArea } from '@/components';
 
 interface Props extends PropsWithChildren {
   className: string;
 }
 
 const PageLayout = ({ children, className }: Props) => {
-  const { isPopoverOpen } = usePopover();
-
   return (
     <PageWrapper className={className}>
       <Header />
-      {isPopoverOpen && <SearchPopover />}
+      <PopoverArea />
       <ContentLayout>{children}</ContentLayout>
     </PageWrapper>
   );

--- a/src/components/templates/PopoverArea/PopoverArea.tsx
+++ b/src/components/templates/PopoverArea/PopoverArea.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+
+import { SearchPopover } from '@/components';
+import usePopover from '@/hooks/utils/usePopover';
+
+const PopoverArea = () => {
+  const { isPopoverOpen } = usePopover();
+
+  useEffect(() => {
+    if (isPopoverOpen) {
+      // scroll overflow
+      document.body.style.overflow = 'hidden';
+      document.body.style.paddingRight = '14px';
+    } else {
+      // scroll overflow
+      document.body.style.overflow = 'auto';
+      document.body.style.paddingRight = '0px';
+    }
+  }, [isPopoverOpen]);
+
+  return isPopoverOpen ? <SearchPopover /> : null;
+};
+
+export default PopoverArea;

--- a/src/components/templates/TrendSection/TrendSection.tsx
+++ b/src/components/templates/TrendSection/TrendSection.tsx
@@ -6,7 +6,7 @@ import { TrendArticles, TrendHashTags, TrendSelect } from '@/components';
 const TrendSection = () => {
   const isDesktop = useMediaQuery({ query: '(min-width: 1280px)' });
   return (
-    <TrendSectionWrapper>
+    <TrendSectionWrapper as="aside">
       <TrendSelect />
       <TrendArticles isMobile={!isDesktop} />
       <TrendHashTags />

--- a/src/pages/author/[id].tsx
+++ b/src/pages/author/[id].tsx
@@ -18,9 +18,8 @@ const PageWrapper = styled('div', {
   position: 'relative',
   height: '100%',
   flexDirection: 'column',
-  width: '680px',
+  width: '100%',
   '@md': {
-    width: '100%',
     flexDirection: 'row',
   },
 });

--- a/src/pages/hashtag/[id].tsx
+++ b/src/pages/hashtag/[id].tsx
@@ -18,9 +18,8 @@ const PageWrapper = styled('div', {
   position: 'relative',
   height: '100%',
   flexDirection: 'column',
-  width: '680px',
+  width: '100%',
   '@md': {
-    width: '100%',
     flexDirection: 'row',
   },
 });

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ export default function Home() {
   const isDesktop = useMediaQuery({ query: '(min-width: 1280px)' });
 
   return (
-    <PageWrapper>
+    <PageWrapper as="main">
       {!isDesktop && <TrendSection />}
       <ArticleSection />
       {isDesktop && <TrendSection />}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,7 +7,7 @@ export default function Home() {
   const isDesktop = useMediaQuery({ query: '(min-width: 1280px)' });
 
   return (
-    <PageWrapper as="main">
+    <PageWrapper>
       {!isDesktop && <TrendSection />}
       <ArticleSection />
       {isDesktop && <TrendSection />}
@@ -21,9 +21,8 @@ const PageWrapper = styled('div', {
   position: 'relative',
   height: '100%',
   flexDirection: 'column',
-  width: '680px',
+  width: '100%',
   '@md': {
-    width: '100%',
     flexDirection: 'row',
   },
 });

--- a/src/pages/keyword/[id].tsx
+++ b/src/pages/keyword/[id].tsx
@@ -18,9 +18,8 @@ const PageWrapper = styled('div', {
   position: 'relative',
   height: '100%',
   flexDirection: 'column',
-  width: '680px',
+  width: '100%',
   '@md': {
-    width: '100%',
     flexDirection: 'row',
   },
 });


### PR DESCRIPTION
#7 를 참고

- [x] 시맨틱 태그 적용
   
  - `header`, `main`, `aside` 등 의미 부여가 필요한 태그들 적용

- [x] 이미지 `alt` 제대로 적용하기

  - 전달할 의미가 없는 이미지는 스크린 리더가 읽지 않도록 묵음 처리

- [x] 검색창과 Popover시의 접근성 높이기

  - `tab`, `shift+tab` 키를 활용하여 Popover를 자유롭게 컨트롤 할 수 있도록 바꾸기
  - `tab`을 통해서 요소를 탐색할때 Popover 내부를 순회하도록 조정
  
  - 적용 전
   
     ![popover_접근성_적용전](https://github.com/k-tech-feed/k-tech-feed-frontend/assets/38908080/8d8f6147-5750-4330-b927-2b9921cc9095)



  - 적용 후
     
    ![popover_표준_적용후](https://github.com/k-tech-feed/k-tech-feed-frontend/assets/38908080/0709447f-2b99-487b-b0c9-f275f06aa1f2)


- [x] 트렌드 선택 부분이나 아티클 카드 내 접근성 높이기
   
   - 스크린리더가 읽는 작업이 필요한 요소들에 대해서 `tabIndex` 적용하기

- [x] 기타 레이아웃 수정 작업